### PR TITLE
Fix handling with old Catch2 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif ()
 # -- options
 option(AZMQ_BUILD_TESTS "run unit tests" ${CMAKE_MASTER_PROJECT})
 option(BUILD_SHARED_LIBS "use the libzmq static or shared" yes)
-option(AZMQ_DEVELOPER "Add verbose warning for developers " no)
+option(AZMQ_DEVELOPER "Add verbose warning for developers " ${CMAKE_MASTER_PROJECT})
 
 # -- config settings --
 set(CMAKE_CXX_STANDARD 11)
@@ -41,9 +41,9 @@ target_include_directories(${PROJECT_NAME} INTERFACE "$<BUILD_INTERFACE:${CMAKE_
                                                      "$<INSTALL_INTERFACE:include>")
 
 if (AZMQ_DEVELOPER)
-  include(cmake/CompilerWarnings.cmake)
-  add_more_warnings_to(${PROJECT_NAME})
-endif()
+    include(cmake/CompilerWarnings.cmake)
+    add_more_warnings_to(${PROJECT_NAME})
+endif ()
 
 if (CMAKE_MASTER_PROJECT AND NOT CMAKE_SKIP_INSTALL_RULES)
     include(AzmqCPack.cmake)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -70,5 +70,6 @@ function(add_more_warnings_to project)
     message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
   endif()
 
-  target_compile_options(${project} INTERFACE ${PROJECT_WARNINGS})
+  # XXX NO! target_compile_options(${project} INTERFACE ${PROJECT_WARNINGS})
+  add_compile_options(${PROJECT_WARNINGS})
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,25 +6,21 @@ if (TEST_INSTALLED_VERSION)
     enable_testing()
 endif ()
 
-find_package(Catch2)
-if ( NOT Catch2 )
-    Include(FetchContent)
-    FetchContent_Declare(
-            Catch2
-            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-            GIT_TAG        v2.13.7)
+# NOTE: current Catch2 version is 3.2.0 is not compatible! CK
+find_package(Catch2 2.13 CONFIG QUIET)
+if (NOT TARGET Catch2::Catch2)
+    include(FetchContent)
+    FetchContent_Declare(Catch2 GIT_REPOSITORY https://github.com/catchorg/Catch2.git GIT_TAG v2.13.7)
     FetchContent_MakeAvailable(Catch2)
     list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
-endif()
+endif ()
 
-link_libraries(Catch2::Catch2)
-
-macro(add_catch_test name)
-    include(CTest)
+macro (add_catch_test name)
+    # XXX not really needed? CK include(CTest)
+    target_link_libraries(${name} Catch2::Catch2)
     include(Catch)
     catch_discover_tests(${name})
-endmacro()
-
+endmacro ()
 
 add_subdirectory(message)
 add_subdirectory(context_ops)


### PR DESCRIPTION
And do not export developer compiler options.

Format CMaleLists.txt again:
```bash
pip install cmake-format
cmake-format -i CMakeLists.txt
```
